### PR TITLE
Feature/167 change typos pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.2.0
+    rev: 7.1.2
     hooks:
     -   id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,8 @@ repos:
     -   id: check-docstring-first
     -   id: check-merge-conflict
     -   id: check-toml
--   repo: https://github.com/adhtruong/typos
-    rev: v1
+-   repo: https://github.com/adhtruong/mirrors-typos
+    rev: v1.31.0
     hooks:
       - id: typos
 -   repo: https://github.com/asottile/add-trailing-comma
@@ -28,7 +28,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.1.2
+    rev: 7.2.0
     hooks:
     -   id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: check-docstring-first
     -   id: check-merge-conflict
     -   id: check-toml
--   repo: https://github.com/crate-ci/typos
+-   repo: https://github.com/adhtruong/typos
     rev: v1
     hooks:
       - id: typos


### PR DESCRIPTION
## Reference Issues/PRs

Resolves #167 

* #167 


## Description

`.pre-commit-config.yaml` is included in repo but uses tagging strategy tags v1, semantic release tag and subpackage tag. This does not interact well pre-commit autoupdate as v1 is a mutable tag. This repos mirrors tags filtering by v1.* so only semantic release tags are fetched.

See https://github.com/crate-ci/typos/issues/390 for discussion in repo.


### References

* https://github.com/crate-ci/typos/issues/390#issuecomment-2764488396
* https://github.com/adhtruong/mirrors-typos?tab=readme-ov-file#background



## Checklist

- [x] I have read the Contributing guidelines.
- [x] My code follows the project's coding standards.
- [x] I have tested my changes.
- [x] I have updated the documentation (if necessary).
