### PR TITLE
Add 3.13 into python versions #165

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Resolves #165 

* #165 

This pull request updates the Python versions used in GitHub Actions workflows to include Python 3.13. The changes ensure compatibility with the latest Python release across testing and dependency installation workflows.

Updates to GitHub Actions workflows:

* [`.github/workflows/codecov.yml`](diffhunk://#diff-512f30627f95d7fcdc76dc362d896351e9a4539994b7ab00b41979e653a6d0a9L13-R13): Updated the Python version used for dependency installation from `3.11` to `3.13`.
* [`.github/workflows/python-package.yml`](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320L18-R18): Added Python 3.13 to the matrix of Python versions for testing.