### PR TITLE
Refactor code with Opus 4.8 max effort

### DIFF
--- a/squiral/__main__.py
+++ b/squiral/__main__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from main import main_cli
+from squiral import main_cli
 
 if __name__ == "__main__":
     raise SystemExit(main_cli())

--- a/squiral/squiral.py
+++ b/squiral/squiral.py
@@ -11,6 +11,7 @@ from math import log10
 from math import sqrt
 
 _directions = [["up", "right"], ["down", "left"]]
+_deltas = {"right": (0, 1), "left": (0, -1), "up": (-1, 0), "down": (1, 0)}
 
 
 def to_where(A: int) -> str:
@@ -34,7 +35,7 @@ def to_where(A: int) -> str:
     return _directions[first][second]
 
 
-def next_point(row: int, col: int, direction: str) -> tuple:
+def next_point(row: int, col: int, direction: str) -> tuple[int, int]:
     """Return next point indices according to current indices and direction.
 
     Args:
@@ -45,15 +46,8 @@ def next_point(row: int, col: int, direction: str) -> tuple:
     Returns:
         tuple: next point indices
     """
-    if direction == "right":
-        col += 1
-    elif direction == "left":
-        col -= 1
-    elif direction == "up":
-        row -= 1
-    elif direction == "down":
-        row += 1
-    return (row, col)
+    dr, dc = _deltas.get(direction, (0, 0))
+    return (row + dr, col + dc)
 
 
 def produce(size: int) -> list:
@@ -67,20 +61,19 @@ def produce(size: int) -> list:
     """
     if size < 1:
         return []
-    s = [[0 for i in range(size)] for j in range(size)]
+    s = [[0] * size for _ in range(size)]
     r = c = (size - 1) // 2
+    last = size * size
     A = 1
     s[r][c] = A
-    while size > 1:
+    while A < last:
         r, c = next_point(r, c, to_where(A))
         A += 1
         s[r][c] = A
-        if A == size**2:
-            return s
     return s
 
 
-def printout(s: list):
+def printout(s: list) -> None:
     """Printout 2D array.
 
     Args:


### PR DESCRIPTION
## Summary

Targeted refactor of the core `squiral` module plus a real bug fix, with behavior preserved (all 119 tests pass, CLI output unchanged).

### Changes
- **`__main__.py`** — fix broken import. `from main import main_cli` raised `ModuleNotFoundError: No module named 'main'`, crashing `python -m squiral`. Now `from squiral import main_cli`; the module runs and matches the README example.
- **`next_point`** — replace the 8-line `if/elif` chain with a `_deltas` lookup map (`row + dr, col + dc`). Unknown directions still return the point unchanged. Return hint tightened to `tuple[int, int]`.
- **`produce`** — replace `while size > 1` + in-loop `if A == size**2: return` with a single `while A < last` loop (`last = size * size` hoisted out, no per-iteration recompute). Simpler matrix init (`[[0] * size for _ in range(size)]`), unused loop vars dropped.
- **`printout`** — add `-> None` return hint.

Net: +8 / −15. House style (terse single-letter names) and all test-imported names (`to_where`, `next_point`, `_directions`, `produce`, `printout`, `main_cli`) kept intact.

### Test plan
- `pytest` → 119 passed
- `python -m squiral 7` → renders the spiral (previously crashed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)