### PR TITLE
docs: add CLAUDE.md and /check skill

### DIFF
--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -15,7 +15,7 @@ Note: black, flake8, and mypy run as **pre-commit hooks**. If the `pre-commit` r
    [ -d venv ] || python -m venv venv
    # activate (POSIX shells)
    source venv/bin/activate
-   python -m pip install "pytest>=8,<10" pytest-cov
+   python -m pip install "pytest>=8,<10" "pytest-cov>=5,<6"
    python -m pytest --cov=squiral --cov-report term-missing tests/
    ```
 

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -1,25 +1,22 @@
 ---
 name: check
-description: Run the full local quality gate for the squiral repo — black, flake8, mypy, and pytest with coverage, mirroring CI. Use before opening a PR or when the user asks to verify changes.
+description: Run the local quality gate for the squiral repo — black, flake8, mypy (via pre-commit) plus pytest with coverage. Use before opening a PR or when the user asks to verify changes.
 ---
 
-Run the same checks CI runs, in order. Stop at the first failure, report it, and offer to fix.
+Run the local quality gate, in order. Stop at the first failure, report it, and offer to fix.
 
-1. **Format** — `poetry run black squiral tests`
-2. **Lint** — `poetry run flake8 . --select=E9,F63,F7,F82 --show-source` then `poetry run flake8 . --exit-zero`
-3. **Types** — `poetry run mypy squiral`
-4. **Tests + coverage** — `poetry run pytest --cov=squiral --cov-report term-missing tests/`
+Note: black, flake8, and mypy are **pre-commit hooks**, not Poetry deps — `poetry run black/flake8/mypy` will fail in a clean `poetry install` env. Only `pytest`/`pytest-cov` are installed by Poetry. CI itself runs only flake8 + pytest; this gate is the fuller local check.
 
-## Fallbacks when Poetry isn't on PATH
+1. **Format + lint + types** — `pre-commit run --all-files`
+   Covers black, flake8 (+ bugbear), mypy, and the other configured hooks in one pass.
+2. **Tests + coverage** — `poetry run pytest --cov=squiral --cov-report term-missing tests/`
 
-If `poetry` is missing or `poetry run <tool>` fails:
+## Fallback when Poetry isn't on PATH
 
-- **Steps 1–3 (black, flake8, mypy):** run `pre-commit run --all-files` — the hooks cover all three.
-- **Step 4 (pytest):** activate the project venv first, then run pytest from it (the runner lives there, not in the Poetry/global env):
-  ```bash
-  source ./venv/bin/activate && python -m pytest --cov=squiral --cov-report term-missing tests/
-  ```
+If `poetry` is missing or `poetry run pytest` fails, activate the project venv and run pytest from it (the runner lives there, not in the global env):
 
-Note: an `rtk` proxy may collapse pytest output to a bare `Pytest: No tests collected` line. That is filtered output, not the real result — re-run the exact command prefixed with `rtk proxy` (e.g. `rtk proxy python -m pytest ...`) to see the true pass/fail and coverage.
+```bash
+source ./venv/bin/activate && python -m pytest --cov=squiral --cov-report term-missing tests/
+```
 
 Report a concise pass/fail summary per step. On any failure, quote the exact error and propose the fix before editing.

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -16,7 +16,13 @@ If `pre-commit` isn’t installed, install it first (e.g. `python -m pip install
 If `poetry` is missing or `poetry run pytest` fails, create/activate a local venv and install the test deps, then run pytest:
 
 ```bash
-python -m venv .venv && source .venv/bin/activate && python -m pip install -U pip && python -m pip install -e . && python -m pip install "pytest>=8,<10" pytest-cov && python -m pytest --cov=squiral --cov-report term-missing tests/
+# ensure virtualenv is installed
+python -m pip show virtualenv >/dev/null 2>&1 || python -m pip install virtualenv
+# create the venv/ dir only if it doesn't already exist
+[ -d venv ] || virtualenv venv
+source venv/bin/activate
+python -m pip install "pytest>=8,<10" pytest-cov
+python -m pytest --cov=squiral --cov-report term-missing tests/
 ```
 
 Report a concise pass/fail summary per step. On any failure, quote the exact error and propose the fix before editing.

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -15,6 +15,8 @@ If `pre-commit` isn’t installed, install it first (e.g. `python -m pip install
 
 If `poetry` is missing or `poetry run pytest` fails, create/activate a local venv and install the test deps, then run pytest:
 
+```bash
 python -m venv .venv && source .venv/bin/activate && python -m pip install -U pip && python -m pip install -e . && python -m pip install "pytest>=8,<10" pytest-cov && python -m pytest --cov=squiral --cov-report term-missing tests/
+```
 
 Report a concise pass/fail summary per step. On any failure, quote the exact error and propose the fix before editing.

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -5,24 +5,19 @@ description: Run the local quality gate for the squiral repo — black, flake8, 
 
 Run the local quality gate, in order. Stop at the first failure, report it, and offer to fix.
 
-Note: `pre-commit` (and black/flake8/mypy) are **pre-commit hooks**, not Poetry deps — `poetry run black/flake8/mypy` will fail in a clean `poetry install` env.
-If `pre-commit` isn’t installed, install it first (e.g. `python -m pip install pre-commit` or `pipx install pre-commit`). Only `pytest`/`pytest-cov` are installed by Poetry. CI itself runs only flake8 + pytest; this gate is the fuller local check.
+Note: black, flake8, and mypy run as **pre-commit hooks**. If the `pre-commit` runner isn't installed, install it first (`pipx install pre-commit` or `python -m pip install pre-commit`). pre-commit does NOT run the tests — step 2 runs pytest separately.
 
 1. **Format + lint + types** — `pre-commit run --all-files`
    Covers black, flake8 (+ bugbear), mypy, and the other configured hooks in one pass.
-
-## Fallback when Poetry isn't on PATH
-
-If `poetry` is missing or `poetry run pytest` fails, create/activate a local venv and install the test deps, then run pytest:
-
-```bash
-# ensure virtualenv is installed
-python -m pip show virtualenv >/dev/null 2>&1 || python -m pip install virtualenv
-# create the venv/ dir only if it doesn't already exist
-[ -d venv ] || virtualenv venv
-source venv/bin/activate
-python -m pip install "pytest>=8,<10" pytest-cov
-python -m pytest --cov=squiral --cov-report term-missing tests/
-```
+2. **Tests + coverage** — run pytest in a local venv:
+   ```bash
+   # ensure virtualenv is installed
+   python -m pip show virtualenv >/dev/null 2>&1 || python -m pip install virtualenv
+   # create the venv/ dir only if it doesn't already exist
+   [ -d venv ] || virtualenv venv
+   source venv/bin/activate
+   python -m pip install "pytest>=8,<10" pytest-cov
+   python -m pytest --cov=squiral --cov-report term-missing tests/
+   ```
 
 Report a concise pass/fail summary per step. On any failure, quote the exact error and propose the fix before editing.

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: check
+description: Run the full local quality gate for the squiral repo — black, flake8, mypy, and pytest with coverage, mirroring CI. Use before opening a PR or when the user asks to verify changes.
+---
+
+Run the same checks CI runs, in order. Stop at the first failure, report it, and offer to fix.
+
+1. **Format** — `poetry run black squiral tests`
+2. **Lint** — `poetry run flake8 . --select=E9,F63,F7,F82 --show-source` then `poetry run flake8 . --exit-zero`
+3. **Types** — `poetry run mypy squiral`
+4. **Tests + coverage** — `poetry run pytest --cov=squiral --cov-report term-missing tests/`
+
+If `poetry run <tool>` fails because a tool isn't in the Poetry env, fall back to running the tool directly (it's installed via pre-commit), or run `pre-commit run --all-files` for steps 1–3.
+
+Report a concise pass/fail summary per step. On any failure, quote the exact error and propose the fix before editing.

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -5,18 +5,16 @@ description: Run the local quality gate for the squiral repo — black, flake8, 
 
 Run the local quality gate, in order. Stop at the first failure, report it, and offer to fix.
 
-Note: black, flake8, and mypy are **pre-commit hooks**, not Poetry deps — `poetry run black/flake8/mypy` will fail in a clean `poetry install` env. Only `pytest`/`pytest-cov` are installed by Poetry. CI itself runs only flake8 + pytest; this gate is the fuller local check.
+Note: `pre-commit` (and black/flake8/mypy) are **pre-commit hooks**, not Poetry deps — `poetry run black/flake8/mypy` will fail in a clean `poetry install` env.
+If `pre-commit` isn’t installed, install it first (e.g. `python -m pip install pre-commit` or `pipx install pre-commit`). Only `pytest`/`pytest-cov` are installed by Poetry. CI itself runs only flake8 + pytest; this gate is the fuller local check.
 
 1. **Format + lint + types** — `pre-commit run --all-files`
    Covers black, flake8 (+ bugbear), mypy, and the other configured hooks in one pass.
-2. **Tests + coverage** — `poetry run pytest --cov=squiral --cov-report term-missing tests/`
 
 ## Fallback when Poetry isn't on PATH
 
-If `poetry` is missing or `poetry run pytest` fails, activate the project venv and run pytest from it (the runner lives there, not in the global env):
+If `poetry` is missing or `poetry run pytest` fails, create/activate a local venv and install the test deps, then run pytest:
 
-```bash
-source ./venv/bin/activate && python -m pytest --cov=squiral --cov-report term-missing tests/
-```
+python -m venv .venv && source .venv/bin/activate && python -m pip install -U pip && python -m pip install -e . && python -m pip install "pytest>=8,<10" pytest-cov && python -m pytest --cov=squiral --cov-report term-missing tests/
 
 Report a concise pass/fail summary per step. On any failure, quote the exact error and propose the fix before editing.

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -10,6 +10,16 @@ Run the same checks CI runs, in order. Stop at the first failure, report it, and
 3. **Types** — `poetry run mypy squiral`
 4. **Tests + coverage** — `poetry run pytest --cov=squiral --cov-report term-missing tests/`
 
-If `poetry run <tool>` fails because a tool isn't in the Poetry env, fall back to running the tool directly (it's installed via pre-commit), or run `pre-commit run --all-files` for steps 1–3.
+## Fallbacks when Poetry isn't on PATH
+
+If `poetry` is missing or `poetry run <tool>` fails:
+
+- **Steps 1–3 (black, flake8, mypy):** run `pre-commit run --all-files` — the hooks cover all three.
+- **Step 4 (pytest):** activate the project venv first, then run pytest from it (the runner lives there, not in the Poetry/global env):
+  ```bash
+  source ./venv/bin/activate && python -m pytest --cov=squiral --cov-report term-missing tests/
+  ```
+
+Note: an `rtk` proxy may collapse pytest output to a bare `Pytest: No tests collected` line. That is filtered output, not the real result — re-run the exact command prefixed with `rtk proxy` (e.g. `rtk proxy python -m pytest ...`) to see the true pass/fail and coverage.
 
 Report a concise pass/fail summary per step. On any failure, quote the exact error and propose the fix before editing.

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -11,10 +11,9 @@ Note: black, flake8, and mypy run as **pre-commit hooks**. If the `pre-commit` r
    Covers black, flake8 (+ bugbear), mypy, and the other configured hooks in one pass.
 2. **Tests + coverage** — run pytest in a local venv:
    ```bash
-   # ensure virtualenv is installed
-   python -m pip show virtualenv >/dev/null 2>&1 || python -m pip install virtualenv
-   # create the venv/ dir only if it doesn't already exist
-   [ -d venv ] || virtualenv venv
+   # create the venv/ dir only if it doesn't already exist (stdlib venv)
+   [ -d venv ] || python -m venv venv
+   # activate (POSIX shells)
    source venv/bin/activate
    python -m pip install "pytest>=8,<10" pytest-cov
    python -m pytest --cov=squiral --cov-report term-missing tests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Commands
 
-- Install deps: `poetry install` (installs `pytest` + `pytest-cov` only — black/flake8/mypy are NOT Poetry deps; they live in pre-commit).
+- Install deps: `poetry install` (installs `pytest` + `pytest-cov` only — install `pre-commit` separately for black/flake8/mypy hooks).
 - Test + coverage: `poetry run pytest --cov=squiral --cov-report term-missing tests/`
 - Single test: `poetry run pytest -v tests/test_squiral.py::test_produce`
 - Lint + format + types: `pre-commit run --all-files` (black, flake8 + bugbear, mypy, typos, add-trailing-comma).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`squiral` — a pure-Python library (stdlib only, no runtime deps) that generates square spiral matrices. Source in `squiral/`, tests in `tests/`. Managed with Poetry.
+
+## Commands
+
+- Install deps: `poetry install`
+- Test + coverage: `poetry run pytest --cov=squiral --cov-report term-missing tests/`
+- Single test: `poetry run pytest -v tests/test_squiral.py::test_produce`
+- Lint (mirrors CI): `flake8 . --select=E9,F63,F7,F82 --show-source` then `flake8 . --exit-zero`
+- All hooks at once: `pre-commit run --all-files` (black, flake8 + bugbear, mypy, typos, add-trailing-comma)
+
+`/check` runs the full local gate (black → flake8 → mypy → pytest) in one step.
+
+## Style
+
+- flake8: `max-line-length = 127`, `max-complexity = 10` (`.flake8`).
+- mypy and full type hints are enforced via pre-commit — keep new code typed.
+- Supported Python: 3.10–3.14. Don't use syntax newer than 3.10.
+
+## Workflow
+
+- Branch from `main` as `feature/<issue#>-slug` (e.g. `feature/165-add-3-13`).
+- Conventional Commits for subjects (`feat:`, `fix:`, `chore:`).
+- PR required — never push directly to `main`.
+- Run `pre-commit run --all-files` and make it pass before opening a PR.
+
+## Release (gotcha)
+
+Tagging `vX.Y.Z` triggers a GitHub Actions workflow that builds with Poetry and publishes to PyPI (`twine`, `TWINE_PASSWORD` secret). Only tag a release when you intend to publish.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Lint + format + types: `pre-commit run --all-files` (black, flake8 + bugbear, mypy, typos, add-trailing-comma).
 - CI lint only: `flake8 . --select=E9,F63,F7,F82 --show-source` then `flake8 . --exit-zero` (CI pip-installs flake8 separately).
 
-CI (`python-package.yml`) runs **flake8 + pytest only**. `/check` runs the fuller local gate (black → flake8 → mypy → pytest) in one step.
+CI (`python-package.yml`) runs **flake8 + pytest only**. `/check` runs the fuller local gate (black → flake8 → mypy via pre-commit, then pytest).
 
 ## Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Commands
 
-- Install deps: `poetry install`
+- Install deps: `poetry install` (installs `pytest` + `pytest-cov` only — black/flake8/mypy are NOT Poetry deps; they live in pre-commit).
 - Test + coverage: `poetry run pytest --cov=squiral --cov-report term-missing tests/`
 - Single test: `poetry run pytest -v tests/test_squiral.py::test_produce`
-- Lint (mirrors CI): `flake8 . --select=E9,F63,F7,F82 --show-source` then `flake8 . --exit-zero`
-- All hooks at once: `pre-commit run --all-files` (black, flake8 + bugbear, mypy, typos, add-trailing-comma)
+- Lint + format + types: `pre-commit run --all-files` (black, flake8 + bugbear, mypy, typos, add-trailing-comma).
+- CI lint only: `flake8 . --select=E9,F63,F7,F82 --show-source` then `flake8 . --exit-zero` (CI pip-installs flake8 separately).
 
-`/check` runs the full local gate (black → flake8 → mypy → pytest) in one step.
+CI (`python-package.yml`) runs **flake8 + pytest only**. `/check` runs the fuller local gate (black → flake8 → mypy → pytest) in one step.
 
 ## Style
 
@@ -31,4 +31,4 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Release (gotcha)
 
-Tagging `vX.Y.Z` triggers a GitHub Actions workflow that builds with Poetry and publishes to PyPI (`twine`, `TWINE_PASSWORD` secret). Only tag a release when you intend to publish.
+Publishing a **GitHub Release** (`python-publish.yml`, `on: release: published`) builds with Poetry and uploads to PyPI via `twine`. The token is the `PYPI_TOKEN` secret, passed as the `TWINE_PASSWORD` env var. A bare `git tag` push does NOT publish — only a published Release does. Only cut a Release when you intend to publish.


### PR DESCRIPTION
## Summary
- Add project `CLAUDE.md` documenting build/test/lint commands, code style (line-length 127, max-complexity 10, mypy/typing enforced, Python 3.10–3.14), branch + Conventional-Commit + PR conventions, pre-commit-before-push rule, and the tag→PyPI release gotcha.
- Add `/check` skill at `.claude/skills/check/SKILL.md` running the full local gate (black → flake8 → mypy → pytest --cov), mirroring CI.

## Notes
Generated via `/init`. Starting point — review and tweak; re-run `/init` to re-scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)