### PR TITLE
fix: make `python -m squiral` work

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,1 @@
 [run]
-omit = */__main__.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-`squiral` — a pure-Python library (stdlib only, no runtime deps) that generates square spiral matrices. Source in `squiral/`, tests in `tests/`. Managed with Poetry.
+`squiral` — a pure-Python library + CLI (stdlib only, no runtime deps) that generates square spiral matrices. Source in `squiral/`, tests in `tests/`. Managed with Poetry.
+
+Public API: `produce(size: int) -> list` (build matrix), `printout(s)` (render it), `main_cli(argv)` (CLI entry). Run the CLI as `poetry run squiral <size>` or `python -m squiral <size>`.
 
 ## Commands
 

--- a/squiral/__main__.py
+++ b/squiral/__main__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from main import main_cli
+from .main import main_cli
 
 if __name__ == "__main__":
     raise SystemExit(main_cli())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import subprocess
+import sys
+
 import pytest
 
 from squiral import main_cli
@@ -21,3 +24,15 @@ def test_main_cli_with_string_input(capsys):
     out, err = capsys.readouterr()
     assert out == ""
     assert err == "Squiral size must be a positive integer!\n"
+
+
+def test_python_m_squiral():
+    """Guard `python -m squiral` entry point (squiral/__main__.py import)."""
+    result = subprocess.run(
+        [sys.executable, "-m", "squiral", "1"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout == "1 \n"
+    assert result.stderr == ""


### PR DESCRIPTION
## Problem

`python -m squiral <size>` failed:

```
ModuleNotFoundError: No module named 'main'
```

`squiral/__main__.py` imported `from main import main_cli` — a top-level module that doesn't exist. The break was invisible because `.coveragerc` omitted `*/__main__.py` and no test exercised the entry point.

## Changes

- **`squiral/__main__.py`**: `from main import main_cli` → `from .main import main_cli`.
- **`tests/test_main.py`**: add `test_python_m_squiral` — subprocess regression test for `python -m squiral`.
- **`.coveragerc`**: remove `omit = */__main__.py`. pytest-cov measures the subprocess, so `__main__.py` reports 100% on its own; the omit was only masking the broken file.

## Verification

- `python -m squiral 3` prints the matrix, exit 0; bad input exits 1.
- `pre-commit run --all-files` ✅ (black, flake8+bugbear, mypy, typos, …)
- `pytest --cov=squiral` ✅ 120 passed, **100%** coverage (now including `__main__.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)